### PR TITLE
Update zimbra-size.sh

### DIFF
--- a/zimbra-size.sh
+++ b/zimbra-size.sh
@@ -50,8 +50,15 @@ while read line ; do
       info=$(mysql -N -e "select size, metadata from mboxgroup${gid}.mail_item where mailbox_id=${mboxid} and id=${fid}")   
       size=$(echo ${info} | egrep -o ":szi.*:" | cut -d: -f2 | cut -c 4- | sed -e 's/e4$//')
       sizeMB="$(expr ${size} / 1024 / 1024 2>/dev/null)" # || echo 0)"
+      sizeKB="$(expr ${size} / 1024 2>/dev/null)"
     else
       sizeMB="0"
+      unset sizeKB
+    fi
+    if [ -z $sizeKB ]; then
+      sizeMB="${sizeMB}"
+    else
+      sizeMB="${sizeMB}.`printf '%.3s' ${sizeKB}`"
     fi
     printf "%9s %9s %10s " ${sizeMB} ${msgcount} ${unread}
     echo ${folder}


### PR DESCRIPTION
Very good script. Thanks to share.
I'd like to sugest this changes to show KB in each folder.

Printing "MB.KB" size in "Size (MB)" column for each folder:
output:
"
[zimbra@zserver scripts]$ ./zimbra-size.sh admin@example.com
admin@example.com's max mailbox size = 12 MB, current mailbox size = 52.62 MB.

size (MB)  msgcount     unread folder

---

```
    0         0          0 /Chats
    0         0          0 /Drafts
0.412       190        179 /Inbox
    0         0          0 /Junk
```

   52.534        11          0 /Sent
"
